### PR TITLE
Fix wrong item id

### DIFF
--- a/src/main/resources/data/largemeals/recipes/cooking/omurice_block.json
+++ b/src/main/resources/data/largemeals/recipes/cooking/omurice_block.json
@@ -5,7 +5,7 @@
       "tag": "forge:crops/rice"
     },
     {
-      "item": "minecraft:raw_chicken"
+      "item": "minecraft:chicken"
     },
     {
       "item": "farmersdelight:cabbage"


### PR DESCRIPTION
`Failed to parse recipe largemeals:cooking/omurice_block[farmersdelight:cooking]: com.google.gson.JsonSyntaxException: Unknown item 'minecraft:raw_chicken'`